### PR TITLE
feat(tools): add composable workspace config packages

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -104,7 +104,7 @@
 - Prepare the next prerelease with client generator surface templating and livon CLI rslib build format controls.
 - Updated dependencies
   - @livon/client@0.27.0-rc.5
-  - @livon/config@0.27.0-rc.5
+  - @livon/vitest@0.27.0-rc.5
 
 ## 0.27.0-rc.4
 
@@ -113,4 +113,4 @@
 - Improve schema ergonomics, generated client JSDoc/typing, dual mini build exports, and docs/site structure.
 - Updated dependencies
   - @livon/client@0.27.0-rc.4
-  - @livon/config@0.27.0-rc.4
+  - @livon/vitest@0.27.0-rc.4

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -104,7 +104,7 @@
 
 - Prepare the next prerelease with client generator surface templating and livon CLI rslib build format controls.
 - Updated dependencies
-  - @livon/config@0.27.0-rc.5
+  - @livon/vitest@0.27.0-rc.5
   - @livon/runtime@0.27.0-rc.5
 
 ## 0.27.0-rc.4
@@ -113,5 +113,5 @@
 
 - Improve schema ergonomics, generated client JSDoc/typing, dual mini build exports, and docs/site structure.
 - Updated dependencies
-  - @livon/config@0.27.0-rc.4
+  - @livon/vitest@0.27.0-rc.4
   - @livon/runtime@0.27.0-rc.4

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -104,7 +104,7 @@
 
 - Prepare the next prerelease with client generator surface templating and livon CLI rslib build format controls.
 - Updated dependencies
-  - @livon/config@0.27.0-rc.5
+  - @livon/vitest@0.27.0-rc.5
   - @livon/runtime@0.27.0-rc.5
 
 ## 0.27.0-rc.4
@@ -113,5 +113,5 @@
 
 - Improve schema ergonomics, generated client JSDoc/typing, dual mini build exports, and docs/site structure.
 - Updated dependencies
-  - @livon/config@0.27.0-rc.4
+  - @livon/vitest@0.27.0-rc.4
   - @livon/runtime@0.27.0-rc.4


### PR DESCRIPTION
## Summary
- add central workspace config packages under `tools/*`:
  - `@livon/typescript`
  - `@livon/eslint`
  - `@livon/rslib`
  - `@livon/rsbuild`
  - `@livon/rspack`
  - `@livon/vitest`
  - `@livon/swc`
- introduce composable builder pattern (`base()`, `node()`, `browser()`, `react()`, `compose(...)`) in TypeScript
- align package exports and source layout for reusable config composition

## Why
- establish one central source of truth per tool
- make config composition explicit and overridable
- enable follow-up migration PRs

## Impact
- foundation-only change, no consumer migration in this PR
