### PR TITLE
chore(policies): enforce ts-based config conventions

### DIFF
--- a/tools/policies/src/checks/project/check-eslint.ts
+++ b/tools/policies/src/checks/project/check-eslint.ts
@@ -3,14 +3,21 @@ import { readFile } from 'node:fs/promises';
 import { exists } from '../../shared/fs-utils.ts';
 
 export const checkEslint = async (projectPath: string): Promise<string[]> => {
-  const eslintPath = path.join(projectPath, 'eslint.config.cjs');
-  if (!(await exists(eslintPath))) {
+  const tsPath = path.join(projectPath, 'eslint.config.ts');
+  const mjsPath = path.join(projectPath, 'eslint.config.mjs');
+  const cjsPath = path.join(projectPath, 'eslint.config.cjs');
+  const jsPath = path.join(projectPath, 'eslint.config.js');
+
+  if (!(await exists(tsPath))) {
+    if ((await exists(mjsPath)) || (await exists(cjsPath)) || (await exists(jsPath))) {
+      return [`${projectPath}: eslint config must be eslint.config.ts`];
+    }
     return [];
   }
 
-  const source = await readFile(eslintPath, 'utf8');
-  if (!source.includes('@livon/config/eslint/base.cjs')) {
-    return [`${projectPath}: eslint.config.cjs must require @livon/config/eslint/base.cjs`];
+  const source = await readFile(tsPath, 'utf8');
+  if (!source.includes('@livon/eslint')) {
+    return [`${projectPath}: eslint config must import @livon/eslint presets`];
   }
 
   return [];

--- a/tools/policies/src/checks/project/check-eslint.ts
+++ b/tools/policies/src/checks/project/check-eslint.ts
@@ -15,7 +15,11 @@ export const checkEslint = async (projectPath: string): Promise<string[]> => {
     return [];
   }
 
-  const source = await readFile(tsPath, 'utf8');
+  const source = await readFile(tsPath, 'utf8').catch(() => null);
+  if (source === null) {
+    return [`${projectPath}: unable to read eslint.config.ts`];
+  }
+
   if (!source.includes('@livon/eslint')) {
     return [`${projectPath}: eslint config must import @livon/eslint presets`];
   }

--- a/tools/policies/src/shared/workspace-root.ts
+++ b/tools/policies/src/shared/workspace-root.ts
@@ -1,8 +1,29 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 
+const findWorkspaceInDirectChildren = (baseDir: string): string | null => {
+  try {
+    const entries = readdirSync(baseDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const candidate = path.join(baseDir, entry.name);
+      if (existsSync(path.join(candidate, 'pnpm-workspace.yaml'))) {
+        return candidate;
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+};
+
 export const resolveWorkspaceBaseDir = (startDir: string = process.cwd()): string => {
-  let currentDir = path.resolve(startDir);
+  const resolvedStartDir = path.resolve(startDir);
+  let currentDir = resolvedStartDir;
 
   while (true) {
     if (existsSync(path.join(currentDir, 'pnpm-workspace.yaml'))) {
@@ -16,6 +37,6 @@ export const resolveWorkspaceBaseDir = (startDir: string = process.cwd()): strin
     currentDir = parentDir;
   }
 
-  const fallback = path.join(path.resolve(startDir), 'livon');
-  return existsSync(fallback) ? fallback : path.resolve(startDir);
+  const fallbackWorkspace = findWorkspaceInDirectChildren(resolvedStartDir);
+  return fallbackWorkspace ?? resolvedStartDir;
 };

--- a/tools/policies/src/shared/workspace-root.ts
+++ b/tools/policies/src/shared/workspace-root.ts
@@ -16,6 +16,6 @@ export const resolveWorkspaceBaseDir = (startDir: string = process.cwd()): strin
     currentDir = parentDir;
   }
 
-  const fallback = path.join(path.resolve(startDir), 'new_livon');
+  const fallback = path.join(path.resolve(startDir), 'livon');
   return existsSync(fallback) ? fallback : path.resolve(startDir);
 };


### PR DESCRIPTION
Depends on #56

## Summary
- update policy checks for new TypeScript-first config conventions
- enforce `eslint.config.ts` preference and `@livon/eslint` usage
- enforce `@livon/typescript/*` tsconfig extends policy
- improve workspace project discovery logic in policies tooling

## Why
- keep governance checks aligned with new centralized config architecture
- prevent regressions back to legacy config patterns

## Impact
- policy gate behavior now validates the new config model
